### PR TITLE
feat: preload features for heatmap generation

### DIFF
--- a/heatmaps/configs/config_template.yaml
+++ b/heatmaps/configs/config_template.yaml
@@ -24,7 +24,9 @@ data_arguments:
   # label dictionary for str: interger mapping (optional)
   label_dict:
     LUAD: 0
-    LSCC: 1                        
+    LSCC: 1
+  # optional directory for precomputed features (h5/pt files)
+  preload_dir: null
 patching_arguments:
   # arguments for patching
   patch_size: 256


### PR DESCRIPTION
## Summary
- allow specifying a directory of precomputed features to skip redundant extraction
- reuse preloaded attention scores for heatmap creation when available
- document optional `preload_dir` in heatmap config template

## Testing
- `python -m py_compile create_heatmaps.py`


------
https://chatgpt.com/codex/tasks/task_e_6894597d11f08324a84a12d93b2495bd