### PR TITLE
Remove interactive prompt from heatmap creation script

### DIFF
--- a/create_heatmaps.py
+++ b/create_heatmaps.py
@@ -97,14 +97,6 @@ if __name__ == '__main__':
         else:
             print ('\n'+key + " : " + str(value))
             
-    decision = input('Continue? Y/N ')
-    if decision in ['Y', 'y', 'Yes', 'yes']:
-        pass
-    elif decision in ['N', 'n', 'No', 'NO']:
-        exit()
-    else:
-        raise NotImplementedError
-
     args = config_dict
     patch_args = argparse.Namespace(**args['patching_arguments'])
     data_args = argparse.Namespace(**args['data_arguments'])


### PR DESCRIPTION
## Summary
- remove confirmation option from `create_heatmaps.py` so it runs without user input

## Testing
- `python -m py_compile create_heatmaps.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68946031ff588324b8850568c5d23e0a